### PR TITLE
Adding unix detection for ttyUSB/ttyACM ports

### DIFF
--- a/SerialAPI.h
+++ b/SerialAPI.h
@@ -17,7 +17,9 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include "JSAPIAuto.h"
 #include "BrowserHost.h"
-
+#ifdef __unix__
+#include <dirent.h>
+#endif
 
 class SerialAPI: public FB::JSAPIAuto
 {
@@ -86,6 +88,25 @@ public:
 		
 			delete [] lpCC;
 		}
+#endif
+#ifdef __unix__
+            DIR *dev = opendir("/dev");
+            struct dirent *ent;
+
+            if (dev != NULL) {
+                while (ent = readdir(dev)) {
+                    std::string name(ent->d_name);
+                    std::string prefix = name.substr(0, 6); 
+                    if (prefix == "ttyUSB" || prefix == "ttyACM") {
+                        std::string fullName = "/dev/";
+                        fullName += name;
+                        std::wstring ws(fullName.begin(), fullName.end());
+                        list.push_back(ws);
+                    }   
+                }   
+
+                closedir(dev);
+            }   
 #endif
 	}
 


### PR DESCRIPTION
This detects serial ports (keeping ttyUSB and ttyACM)
It is not a perfect method but it works in most case and still better than nothing anyway